### PR TITLE
feat: add dynamic metadata for public pages

### DIFF
--- a/src/app/(public)/evaluation/page.tsx
+++ b/src/app/(public)/evaluation/page.tsx
@@ -6,13 +6,37 @@ import { EvaluationForm } from "./_components/EvaluationForm";
 import { Header } from "./_components/Header";
 import EvaluationLoading from "./loading";
 
-export const metadata: Metadata = {
-  title: "Event Evaluation",
-  description: "Provide feedback on your event experience.",
-};
-
 interface EvaluationPageProps {
   searchParams: Promise<{ eventId?: string }>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: EvaluationPageProps): Promise<Metadata> {
+  const { eventId } = await searchParams;
+
+  if (!eventId) {
+    return {
+      title: "Event Evaluation",
+      description: "Provide feedback on your event experience.",
+    };
+  }
+
+  const event = await getEventById((await cookies()).getAll(), {
+    id: eventId,
+  }).catch(() => null);
+
+  if (!event) {
+    return {
+      title: "Event Evaluation",
+      description: "Provide feedback on your event experience.",
+    };
+  }
+
+  return {
+    title: `${event.eventTitle} - Evaluation`,
+    description: `Share your feedback on ${event.eventTitle}. Your input helps us improve future events.`,
+  };
 }
 
 export default async function EvaluationPage({

--- a/src/app/(public)/evaluation/success/page.tsx
+++ b/src/app/(public)/evaluation/success/page.tsx
@@ -3,13 +3,37 @@ import { cookies } from "next/headers";
 import { getEventById } from "@/server/events/queries/getEventById";
 import { EvaluationSuccessContent } from "./_components/EvaluationSuccessContent";
 
-export const metadata: Metadata = {
-  title: "Evaluation Submitted",
-  description: "Thank you for sharing your feedback.",
-};
-
 interface EvaluationSuccessPageProps {
   searchParams: Promise<{ eventId?: string }>;
+}
+
+export async function generateMetadata({
+  searchParams,
+}: EvaluationSuccessPageProps): Promise<Metadata> {
+  const { eventId } = await searchParams;
+
+  if (!eventId) {
+    return {
+      title: "Evaluation Submitted",
+      description: "Thank you for sharing your feedback.",
+    };
+  }
+
+  const event = await getEventById((await cookies()).getAll(), {
+    id: eventId,
+  }).catch(() => null);
+
+  if (!event) {
+    return {
+      title: "Evaluation Submitted",
+      description: "Thank you for sharing your feedback.",
+    };
+  }
+
+  return {
+    title: `Thank You - ${event.eventTitle} Evaluation`,
+    description: `Your feedback on ${event.eventTitle} has been submitted. Thank you for helping us improve!`,
+  };
 }
 
 export default async function EvaluationSuccessPage({

--- a/src/app/(public)/events/[eventId]/page.tsx
+++ b/src/app/(public)/events/[eventId]/page.tsx
@@ -1,16 +1,34 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { Suspense } from "react";
+import { stripRichText } from "@/lib/utils/stripRichText";
 import { getEventById } from "@/server/events/queries/getEventById";
 import { EventDetailsContent } from "../_components/EventDetailsContent";
 import { EventDetailsHero } from "../_components/EventDetailsHero";
 import EventPageDetailsLoading from "./loading";
 import NotFound from "./not-found";
 
-export const metadata: Metadata = {
-  title: "Event Details",
-  description: "View event details, schedule, and registration information.",
-};
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ eventId: string }>;
+}): Promise<Metadata> {
+  const { eventId } = await params;
+  const cookieStore = await cookies();
+
+  const event = await getEventById(cookieStore.getAll(), { id: eventId }).catch(
+    () => null,
+  );
+
+  if (!event) {
+    return { title: "Event Not Found" };
+  }
+
+  return {
+    title: event.eventTitle,
+    description: stripRichText(event.description).slice(0, 160),
+  };
+}
 
 export default async function EventDetailsPage({
   params,

--- a/src/app/(public)/networks/page.tsx
+++ b/src/app/(public)/networks/page.tsx
@@ -1,9 +1,16 @@
+import type { Metadata } from "next";
 import { Suspense } from "react";
 import NetworksBenefits from "./_components/NetworksBenefits";
 import NetworksCTA from "./_components/NetworksCTA";
 import { NetworksHero } from "./_components/NetworksHero";
 import NetworksListSection from "./_components/NetworksListSection";
 import NetworksLoading from "./loading";
+
+export const metadata: Metadata = {
+  title: "Networks",
+  description:
+    "Join the IBC network of business leaders and organizations driving progress in Western Visayas.",
+};
 
 export default function Page() {
   return (

--- a/src/app/registration/[eventId]/info/page.tsx
+++ b/src/app/registration/[eventId]/info/page.tsx
@@ -1,13 +1,32 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { Suspense } from "react";
 import type { RegistrationInformationPageProps } from "@/lib/types/route";
+import { getRegistrationEventDetails } from "@/server/registration/queries/getRegistrationEventDetails";
 import { RegistrationInfoPageContent } from "./_components/RegistrationInfoPageContent";
 import Loading from "./loading";
 
-export const metadata: Metadata = {
-  title: "Registration Information",
-  description: "Review and confirm your event registration details.",
-};
+export async function generateMetadata({
+  params,
+}: RegistrationInformationPageProps): Promise<Metadata> {
+  const { eventId } = await params;
+
+  const event = await getRegistrationEventDetails((await cookies()).getAll(), {
+    eventId,
+  }).catch(() => null);
+
+  if (!event) {
+    return {
+      title: "Registration Information",
+      description: "Review and confirm your event registration details.",
+    };
+  }
+
+  return {
+    title: `Registration Details - ${event.eventTitle}`,
+    description: `Review your registration for ${event.eventTitle}. Confirm your details and complete your registration.`,
+  };
+}
 
 export default function InfoPageWrapper({
   params,

--- a/src/app/registration/[eventId]/page.tsx
+++ b/src/app/registration/[eventId]/page.tsx
@@ -1,14 +1,33 @@
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { Suspense } from "react";
-// import CenterSpinner from "@/components/CenterSpinner";
 import type { RegistrationRouteProps } from "@/lib/types/route";
+import { stripRichText } from "@/lib/utils/stripRichText";
+import { getRegistrationEventDetails } from "@/server/registration/queries/getRegistrationEventDetails";
 import { RegistrationPageContent } from "./_components/RegistrationPageContent";
 import Loading from "./loading";
 
-export const metadata: Metadata = {
-  title: "Event Registration",
-  description: "Complete your registration for the event.",
-};
+export async function generateMetadata({
+  params,
+}: RegistrationRouteProps): Promise<Metadata> {
+  const { eventId } = await params;
+
+  const event = await getRegistrationEventDetails((await cookies()).getAll(), {
+    eventId,
+  }).catch(() => null);
+
+  if (!event) {
+    return {
+      title: "Event Registration",
+      description: "Complete your registration for the event.",
+    };
+  }
+
+  return {
+    title: `Register - ${event.eventTitle}`,
+    description: stripRichText(event.description).slice(0, 160),
+  };
+}
 
 export default function Page({ params, searchParams }: RegistrationRouteProps) {
   return (

--- a/src/lib/utils/stripRichText.ts
+++ b/src/lib/utils/stripRichText.ts
@@ -1,0 +1,12 @@
+import sanitizeHtml from "sanitize-html";
+
+export function stripRichText(html: string | null | undefined): string {
+  if (!html) return "";
+
+  return sanitizeHtml(html, {
+    allowedTags: [],
+    allowedAttributes: {},
+  })
+    .trim()
+    .replace(/\s+/g, " ");
+}


### PR DESCRIPTION
## 🎫 Jira Ticket(s)

<!-- List the Jira IDs associated with this PR. Prefix is BOF- -->

- None

## 📝 Description

<!-- What does this PR do? Why is this change necessary? -->

- Add `generateMetadata` to event detail page for dynamic title/description based on event data
- Add `generateMetadata` to registration pages (main and info step) showing event name in title
- Add `generateMetadata` to evaluation pages (form and success) showing event name when eventId is provided
- Add missing metadata export to networks page
- Create `stripRichText` utility to clean HTML tags from rich text descriptions for use in metadata

## 🛠️ Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## 📸 Screenshots / Video

<!-- If applicable, add screenshots or screen recordings to demonstrate the UI changes. If code related, you may add code snippets or logs to help explain the changes. -->

N/A - metadata changes only, no UI changes

## ⚠️ Concerns / Known Issues

<!-- Are there any edge cases, unfinished parts, or specific things the reviewer should look out for? -->

- OG images to be added separately
- Build has a pre-existing type error in `admin/members/[id]/edit/page.tsx` (unrelated to this change)

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [ ] I have generated Supabase types (if schema changed).
- [ ] I have checked for mobile responsiveness.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added necessary documentation (if appropriate).