### PR TITLE
Feat/dynamic website content

### DIFF
--- a/__tests__/integration/server/website-content/getWebsiteContentSectionsSummary.test.ts
+++ b/__tests__/integration/server/website-content/getWebsiteContentSectionsSummary.test.ts
@@ -3,14 +3,21 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockEq = vi.fn();
 const mockSelect = vi.fn(() => ({ eq: mockEq }));
 const mockFrom = vi.fn(() => ({ select: mockSelect }));
-const mockCreateActionClient = vi.fn(async () => ({ from: mockFrom }));
+const mockCreateClient = vi.fn(async () => ({ from: mockFrom }));
+const mockCookies = vi.fn(async () => ({
+  getAll: () => [{ name: "sb-access-token", value: "token" }],
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: mockCookies,
+}));
 
 vi.mock("@/lib/supabase/server", () => ({
-  createActionClient: mockCreateActionClient,
+  createClient: mockCreateClient,
 }));
 
 const { getWebsiteContentSectionsSummary } = await import(
-  "@/server/website-content/mutations/getWebsiteContentSectionsSummary"
+  "@/server/website-content/queries/getWebsiteContentSectionsSummary"
 );
 
 describe("getWebsiteContentSectionsSummary", () => {
@@ -34,6 +41,9 @@ describe("getWebsiteContentSectionsSummary", () => {
       landing_page_benefits: { updatedAt: null, cardCount: 0 },
     });
     expect(mockFrom).toHaveBeenCalledWith("WebsiteContent");
+    expect(mockCreateClient).toHaveBeenCalledWith([
+      { name: "sb-access-token", value: "token" },
+    ]);
     expect(mockEq).toHaveBeenCalledWith("isActive", true);
   });
 

--- a/__tests__/integration/server/website-content/getWebsiteContentSectionsSummary.test.ts
+++ b/__tests__/integration/server/website-content/getWebsiteContentSectionsSummary.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockEq = vi.fn();
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({ select: mockSelect }));
+const mockCreateActionClient = vi.fn(async () => ({ from: mockFrom }));
+
+vi.mock("@/lib/supabase/server", () => ({
+  createActionClient: mockCreateActionClient,
+}));
+
+const { getWebsiteContentSectionsSummary } = await import(
+  "@/server/website-content/mutations/getWebsiteContentSectionsSummary"
+);
+
+describe("getWebsiteContentSectionsSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFrom.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+  });
+
+  it("returns empty summary defaults when no rows exist", async () => {
+    mockEq.mockResolvedValueOnce({ data: [], error: null });
+
+    const result = await getWebsiteContentSectionsSummary();
+
+    expect(result).toEqual({
+      vision_mission: { updatedAt: null, cardCount: 0 },
+      goals: { updatedAt: null, cardCount: 0 },
+      company_thrusts: { updatedAt: null, cardCount: 0 },
+      board_of_trustees: { updatedAt: null, cardCount: 0 },
+      secretariat: { updatedAt: null, cardCount: 0 },
+      landing_page_benefits: { updatedAt: null, cardCount: 0 },
+    });
+    expect(mockFrom).toHaveBeenCalledWith("WebsiteContent");
+    expect(mockEq).toHaveBeenCalledWith("isActive", true);
+  });
+
+  it("aggregates latest updatedAt and distinct card counts by section", async () => {
+    mockEq.mockResolvedValueOnce({
+      data: [
+        {
+          section: "goals",
+          entryKey: "goal-1",
+          updatedAt: "2026-04-26T09:00:00.000Z",
+        },
+        {
+          section: "goals",
+          entryKey: "goal-1",
+          updatedAt: "2026-04-26T10:00:00.000Z",
+        },
+        {
+          section: "goals",
+          entryKey: "goal-2",
+          updatedAt: "2026-04-26T08:00:00.000Z",
+        },
+        {
+          section: "board_of_trustees",
+          entryKey: "trustee-1",
+          updatedAt: "2026-04-25T08:00:00.000Z",
+        },
+      ],
+      error: null,
+    });
+
+    const result = await getWebsiteContentSectionsSummary();
+
+    expect(result.goals).toEqual({
+      updatedAt: "2026-04-26T10:00:00.000Z",
+      cardCount: 2,
+    });
+    expect(result.board_of_trustees).toEqual({
+      updatedAt: "2026-04-25T08:00:00.000Z",
+      cardCount: 1,
+    });
+    expect(result.vision_mission).toEqual({ updatedAt: null, cardCount: 0 });
+  });
+
+  it("throws when summary fetch fails", async () => {
+    mockEq.mockResolvedValueOnce({
+      data: null,
+      error: { message: "permission denied" },
+    });
+
+    await expect(getWebsiteContentSectionsSummary()).rejects.toThrow(
+      "Failed to fetch website content summary: permission denied",
+    );
+  });
+});

--- a/__tests__/integration/server/website-content/saveWebsiteContentSection.test.ts
+++ b/__tests__/integration/server/website-content/saveWebsiteContentSection.test.ts
@@ -22,7 +22,10 @@ import type { SaveWebsiteContentSectionInput } from "@/server/website-content/ty
 // --- Module Mocks ---
 
 const mockUpsertWebsiteContentRows = vi.fn();
+const mockDeactivateWebsiteContentEntriesBySection = vi.fn();
 vi.mock("@/server/website-content/mutations/upsertWebsiteContentRow", () => ({
+  deactivateWebsiteContentEntriesBySection:
+    mockDeactivateWebsiteContentEntriesBySection,
   upsertWebsiteContentRows: mockUpsertWebsiteContentRows,
 }));
 
@@ -45,6 +48,7 @@ describe("saveWebsiteContentSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default mock: successful response
+    mockDeactivateWebsiteContentEntriesBySection.mockResolvedValue(undefined);
     mockUpsertWebsiteContentRows.mockResolvedValue(undefined);
   });
 
@@ -68,6 +72,10 @@ describe("saveWebsiteContentSection", () => {
     const result = await saveWebsiteContentSection(input);
 
     expect(result.updatedAt).toBeDefined();
+    expect(mockDeactivateWebsiteContentEntriesBySection).toHaveBeenCalledWith(
+      "vision_mission",
+      ["vision", "mission"],
+    );
     expect(mockUpsertWebsiteContentRows).toHaveBeenCalledWith([
       {
         section: "vision_mission",
@@ -114,6 +122,10 @@ describe("saveWebsiteContentSection", () => {
 
     await saveWebsiteContentSection(input);
 
+    expect(mockDeactivateWebsiteContentEntriesBySection).toHaveBeenCalledWith(
+      "goals",
+      ["goal-1"],
+    );
     expect(mockUpsertWebsiteContentRows).toHaveBeenCalledWith(
       expect.arrayContaining([
         expect.objectContaining({
@@ -243,6 +255,11 @@ describe("saveWebsiteContentSection", () => {
     };
 
     await saveWebsiteContentSection(input);
+
+    expect(mockDeactivateWebsiteContentEntriesBySection).toHaveBeenCalledWith(
+      "goals",
+      [],
+    );
 
     expect(revalidatePath).toHaveBeenCalledWith("/", "page");
     expect(revalidatePath).toHaveBeenCalledWith("/about", "page");
@@ -413,6 +430,43 @@ describe("saveWebsiteContentSection", () => {
     await expect(saveWebsiteContentSection(input)).rejects.toThrow(
       "Supabase RPC failed: duplicate key violation",
     );
+  });
+
+  it("should propagate error when deactivating removed entries fails", async () => {
+    mockDeactivateWebsiteContentEntriesBySection.mockRejectedValue(
+      new Error("Failed to deactivate removed website content rows"),
+    );
+
+    const input: SaveWebsiteContentSectionInput = {
+      section: "goals",
+      form: {
+        title: "unused",
+        subtitle: "unused",
+        paragraph: "unused",
+        visionParagraph: "unused",
+        missionParagraph: "unused",
+        icon: "unused",
+        imageUrl: "unused",
+        cardPlacement: "unused",
+      },
+      cards: [
+        {
+          entryKey: "goal-1",
+          title: "Goal",
+          subtitle: "",
+          paragraph: "Body",
+          icon: "Target",
+          imageUrl: "",
+          cardPlacement: "1",
+          group: null,
+        },
+      ],
+    };
+
+    await expect(saveWebsiteContentSection(input)).rejects.toThrow(
+      "Failed to deactivate removed website content rows",
+    );
+    expect(mockUpsertWebsiteContentRows).not.toHaveBeenCalled();
   });
 
   // ✅ EDGE CASE: Empty cards array for non-vision_mission section

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "date-fns": "4.1.0",
+        "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
         "embla-carousel-react": "^8.6.0",
         "file-type": "^22.0.1",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,36 @@
 import type { NextConfig } from "next";
 
+const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "form-action 'self'",
+      "frame-ancestors 'none'",
+      "object-src 'none'",
+      "img-src 'self' data: https:",
+      "font-src 'self' data: https:",
+      "style-src 'self' 'unsafe-inline' https:",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+      "connect-src 'self' https: wss:",
+      "upgrade-insecure-requests",
+    ].join("; "),
+  },
+  {
+    key: "X-Frame-Options",
+    value: "DENY",
+  },
+  {
+    key: "X-Content-Type-Options",
+    value: "nosniff",
+  },
+  {
+    key: "Referrer-Policy",
+    value: "strict-origin-when-cross-origin",
+  },
+];
+
 const nextConfig: NextConfig = {
   /* config options here */
   output: process.env.NODE_ENV === "production" ? "standalone" : undefined,
@@ -75,6 +106,14 @@ const nextConfig: NextConfig = {
     dangerouslyAllowLocalIP: true,
   },
   serverExternalPackages: ["react-email", "@react-email/render"],
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,7 @@
 import type { NextConfig } from "next";
 
+const isProduction = process.env.NODE_ENV === "production";
+
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
@@ -12,7 +14,9 @@ const securityHeaders = [
       "img-src 'self' data: https:",
       "font-src 'self' data: https:",
       "style-src 'self' 'unsafe-inline' https:",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+      isProduction
+        ? "script-src 'self' 'unsafe-inline' https://unpkg.com"
+        : "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
       "connect-src 'self' https: wss:",
       "upgrade-insecure-requests",
     ].join("; "),

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "4.1.0",
+    "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "embla-carousel-react": "^8.6.0",
     "file-type": "^22.0.1",

--- a/src/app/admin/website-content/_components/LucideIconPicker.tsx
+++ b/src/app/admin/website-content/_components/LucideIconPicker.tsx
@@ -73,6 +73,7 @@ import { cn } from "@/lib/utils";
 interface LucideIconPickerProps {
   selectedIcon: string;
   onSelect: (iconName: string) => void;
+  disabled?: boolean;
 }
 
 interface IconOption {
@@ -144,6 +145,7 @@ const ICON_OPTIONS: IconOption[] = [
 export function LucideIconPicker({
   selectedIcon,
   onSelect,
+  disabled = false,
 }: LucideIconPickerProps) {
   const [open, setOpen] = useState(false);
 
@@ -164,6 +166,7 @@ export function LucideIconPicker({
             buttonVariants({ variant: "outline", size: "sm" }),
             "h-9 w-36 justify-between overflow-hidden px-3",
           )}
+          disabled={disabled}
         >
           <span className="flex min-w-0 items-center gap-2">
             {SelectedIcon ? (
@@ -190,6 +193,7 @@ export function LucideIconPicker({
                         ? "border-primary bg-primary/10 text-primary"
                         : "border-border hover:bg-muted",
                     )}
+                    disabled={disabled}
                     key={name}
                     onClick={() => {
                       onSelect(name);

--- a/src/app/admin/website-content/_components/RichTextEditorField.tsx
+++ b/src/app/admin/website-content/_components/RichTextEditorField.tsx
@@ -7,6 +7,7 @@ interface MarkdownTextareaProps {
   rows?: number;
   value: string;
   onChange: (value: string) => void;
+  disabled?: boolean;
 }
 
 export function MarkdownTextarea({
@@ -14,10 +15,11 @@ export function MarkdownTextarea({
   rows,
   value,
   onChange,
+  disabled = false,
 }: MarkdownTextareaProps) {
   return (
     <div
-      className="space-y-2"
+      className={`space-y-2 ${disabled ? "pointer-events-none opacity-60" : ""}`}
       style={{ minHeight: rows ? `${Math.max(rows, 8) * 24}px` : undefined }}
     >
       <StandaloneRichTextEditor

--- a/src/app/admin/website-content/_components/WebsiteContentManagementPage.tsx
+++ b/src/app/admin/website-content/_components/WebsiteContentManagementPage.tsx
@@ -11,6 +11,16 @@ import {
   XIcon,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useWebsiteContentEditor } from "../_hooks/useWebsiteContentEditor";
@@ -37,7 +47,6 @@ const sectionCards = [
     accentClass: "bg-sky-500",
     iconClass: "bg-sky-50 text-sky-600",
     icon: Compass,
-    fields: "2 fields",
   },
   {
     key: "goals" as const,
@@ -46,7 +55,6 @@ const sectionCards = [
     accentClass: "bg-emerald-500",
     iconClass: "bg-emerald-50 text-emerald-600",
     icon: Target,
-    fields: "3 fields",
   },
   {
     key: "company_thrusts" as const,
@@ -55,7 +63,6 @@ const sectionCards = [
     accentClass: "bg-amber-500",
     iconClass: "bg-amber-50 text-amber-600",
     icon: Building2,
-    fields: "3 fields",
   },
   {
     key: "board_of_trustees" as const,
@@ -64,7 +71,6 @@ const sectionCards = [
     accentClass: "bg-rose-500",
     iconClass: "bg-rose-50 text-rose-600",
     icon: Landmark,
-    fields: "4 fields",
   },
   {
     key: "secretariat" as const,
@@ -73,7 +79,6 @@ const sectionCards = [
     accentClass: "bg-cyan-500",
     iconClass: "bg-cyan-50 text-cyan-600",
     icon: Users,
-    fields: "3 fields",
   },
   {
     key: "landing_page_benefits" as const,
@@ -82,12 +87,12 @@ const sectionCards = [
     accentClass: "bg-indigo-500",
     iconClass: "bg-indigo-50 text-indigo-600",
     icon: Sparkles,
-    fields: "3 fields",
   },
 ];
 
 export function WebsiteContentManagementPage() {
   const [activeSection, setActiveSection] = useState<SectionKey | null>(null);
+  const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
   const {
     form,
     cards,
@@ -96,11 +101,38 @@ export function WebsiteContentManagementPage() {
     setCardField,
     replaceCards,
     addCard,
+    isDeleteMode,
+    selectedCardEntryKeys,
+    enterDeleteMode,
+    cancelDeleteMode,
+    selectAllCards,
+    unselectAllCards,
+    toggleCardSelected,
+    deleteSelectedCards,
     save,
     isSavingSection,
     isLoadingSection,
     updatedAtBySection,
+    cardCountBySection,
+    hasLoadedSectionSummaries,
   } = useWebsiteContentEditor(activeSection);
+
+  const hasSelectedCards = selectedCardEntryKeys.size > 0;
+  const selectedCount = selectedCardEntryKeys.size;
+  const isSectionActionDisabled = isSavingSection || isLoadingSection;
+
+  const handleDeleteCardsClick = () => {
+    if (!isDeleteMode) {
+      enterDeleteMode();
+      return;
+    }
+
+    if (!hasSelectedCards) {
+      return;
+    }
+
+    setIsDeleteConfirmOpen(true);
+  };
 
   const selectedCard = useMemo(
     () => sectionCards.find((section) => section.key === activeSection) ?? null,
@@ -108,12 +140,24 @@ export function WebsiteContentManagementPage() {
   );
 
   const updatedAtDisplay = (section: SectionKey) => {
+    if (!hasLoadedSectionSummaries) {
+      return "Loading...";
+    }
+
     const updatedAt = updatedAtBySection[section];
     if (!updatedAt) {
       return "Not updated yet";
     }
 
     return new Date(updatedAt).toLocaleString();
+  };
+
+  const savedCardsDisplay = (section: SectionKey) => {
+    if (!hasLoadedSectionSummaries) {
+      return "Loading...";
+    }
+
+    return String(cardCountBySection[section] ?? 0);
   };
 
   const renderActiveForm = () => {
@@ -141,9 +185,19 @@ export function WebsiteContentManagementPage() {
         return (
           <GoalsSection
             cards={cards}
+            hasSelectedCards={hasSelectedCards}
+            isDeleteMode={isDeleteMode}
+            isSectionActionDisabled={isSectionActionDisabled}
             onAddCard={() => addCard()}
+            onCancelDeleteMode={cancelDeleteMode}
             onCardFieldChange={setCardField}
+            onDeleteCardsClick={handleDeleteCardsClick}
+            onSelectAllCards={selectAllCards}
+            onToggleCardSelected={toggleCardSelected}
+            onUnselectAllCards={unselectAllCards}
             placeholders={placeholders}
+            selectedCardEntryKeys={selectedCardEntryKeys}
+            selectedCount={selectedCount}
           />
         );
 
@@ -151,9 +205,19 @@ export function WebsiteContentManagementPage() {
         return (
           <CompanyThrustsSection
             cards={cards}
+            hasSelectedCards={hasSelectedCards}
+            isDeleteMode={isDeleteMode}
+            isSectionActionDisabled={isSectionActionDisabled}
             onAddCard={() => addCard()}
+            onCancelDeleteMode={cancelDeleteMode}
             onCardFieldChange={setCardField}
+            onDeleteCardsClick={handleDeleteCardsClick}
+            onSelectAllCards={selectAllCards}
+            onToggleCardSelected={toggleCardSelected}
+            onUnselectAllCards={unselectAllCards}
             placeholders={placeholders}
+            selectedCardEntryKeys={selectedCardEntryKeys}
+            selectedCount={selectedCount}
           />
         );
 
@@ -161,10 +225,20 @@ export function WebsiteContentManagementPage() {
         return (
           <BoardOfTrusteesSection
             cards={cards}
+            hasSelectedCards={hasSelectedCards}
+            isDeleteMode={isDeleteMode}
+            isSectionActionDisabled={isSectionActionDisabled}
             onAddCard={(group) => addCard(group)}
+            onCancelDeleteMode={cancelDeleteMode}
             onCardFieldChange={setCardField}
             onCardsReorder={replaceCards}
+            onDeleteCardsClick={handleDeleteCardsClick}
+            onSelectAllCards={selectAllCards}
+            onToggleCardSelected={toggleCardSelected}
+            onUnselectAllCards={unselectAllCards}
             placeholders={placeholders}
+            selectedCardEntryKeys={selectedCardEntryKeys}
+            selectedCount={selectedCount}
           />
         );
 
@@ -172,10 +246,20 @@ export function WebsiteContentManagementPage() {
         return (
           <SecretariatSection
             cards={cards}
+            hasSelectedCards={hasSelectedCards}
+            isDeleteMode={isDeleteMode}
+            isSectionActionDisabled={isSectionActionDisabled}
             onAddCard={() => addCard()}
+            onCancelDeleteMode={cancelDeleteMode}
             onCardFieldChange={setCardField}
             onCardsReorder={replaceCards}
+            onDeleteCardsClick={handleDeleteCardsClick}
+            onSelectAllCards={selectAllCards}
+            onToggleCardSelected={toggleCardSelected}
+            onUnselectAllCards={unselectAllCards}
             placeholders={placeholders}
+            selectedCardEntryKeys={selectedCardEntryKeys}
+            selectedCount={selectedCount}
           />
         );
 
@@ -183,9 +267,19 @@ export function WebsiteContentManagementPage() {
         return (
           <LandingBenefitsSection
             cards={cards}
+            hasSelectedCards={hasSelectedCards}
+            isDeleteMode={isDeleteMode}
+            isSectionActionDisabled={isSectionActionDisabled}
             onAddCard={() => addCard()}
+            onCancelDeleteMode={cancelDeleteMode}
             onCardFieldChange={setCardField}
+            onDeleteCardsClick={handleDeleteCardsClick}
+            onSelectAllCards={selectAllCards}
+            onToggleCardSelected={toggleCardSelected}
+            onUnselectAllCards={unselectAllCards}
             placeholders={placeholders}
+            selectedCardEntryKeys={selectedCardEntryKeys}
+            selectedCount={selectedCount}
           />
         );
 
@@ -234,7 +328,7 @@ export function WebsiteContentManagementPage() {
                   </div>
                 </CardHeader>
                 <CardContent className="space-y-2 text-muted-foreground text-sm">
-                  <p>Fields: {section.fields}</p>
+                  <p>Saved cards: {savedCardsDisplay(section.key)}</p>
                   <p>Updated: {updatedAtDisplay(section.key)}</p>
                 </CardContent>
               </Card>
@@ -246,6 +340,7 @@ export function WebsiteContentManagementPage() {
       <DialogPrimitive.Root
         onOpenChange={(open) => {
           if (!open) {
+            cancelDeleteMode();
             setActiveSection(null);
           }
         }}
@@ -286,9 +381,11 @@ export function WebsiteContentManagementPage() {
                 </div>
 
                 <div className="border-border border-t bg-background px-6 py-4 sm:px-7">
-                  <div className="flex flex-wrap justify-end gap-2">
+                  <div className="flex flex-wrap items-center justify-end gap-2">
                     <Button
-                      disabled={isSavingSection || isLoadingSection}
+                      disabled={
+                        isSavingSection || isLoadingSection || isDeleteMode
+                      }
                       onClick={save}
                     >
                       {isSavingSection ? "Saving..." : "Save Changes"}
@@ -300,6 +397,35 @@ export function WebsiteContentManagementPage() {
           </DialogPrimitive.Viewport>
         </DialogPrimitive.Portal>
       </DialogPrimitive.Root>
+
+      <AlertDialog
+        onOpenChange={setIsDeleteConfirmOpen}
+        open={isDeleteConfirmOpen}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete selected cards?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will remove {selectedCardEntryKeys.size} selected card
+              {selectedCardEntryKeys.size === 1 ? "" : "s"} from the editor.
+              Click Save Changes to persist this deletion.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={!hasSelectedCards}
+              onClick={() => {
+                deleteSelectedCards();
+                setIsDeleteConfirmOpen(false);
+              }}
+            >
+              Confirm Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }

--- a/src/app/admin/website-content/_components/sections/BoardOfTrusteesSection.tsx
+++ b/src/app/admin/website-content/_components/sections/BoardOfTrusteesSection.tsx
@@ -7,18 +7,29 @@ import { GripVertical } from "lucide-react";
 import Image from "next/image";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { reorderInList } from "../../_hooks/reorderInList";
 import { useBoardCardGroups } from "../../_hooks/useBoardCardGroups";
 import { usePersonalImageUpload } from "../../_hooks/usePersonalImageUpload";
-import type { BoardOfTrusteesSectionProps } from "../../_types/section-props";
+import type { BoardOfTrusteesSectionProps } from "../../_types/sectionProps";
 
 type BoardGroup = "featured" | "officers" | "trustees" | "other";
 
 export function BoardOfTrusteesSection({
   cards,
   placeholders,
+  isSectionActionDisabled,
+  isDeleteMode,
+  hasSelectedCards,
+  selectedCount,
+  selectedCardEntryKeys,
   onAddCard,
+  onDeleteCardsClick,
+  onCancelDeleteMode,
+  onSelectAllCards,
+  onUnselectAllCards,
+  onToggleCardSelected,
   onCardFieldChange,
   onCardsReorder,
 }: BoardOfTrusteesSectionProps) {
@@ -93,39 +104,66 @@ export function BoardOfTrusteesSection({
       form.setFieldValue("subtitle", card.subtitle);
     }, [card.subtitle, card.title, form]);
 
+    const isSelected = selectedCardEntryKeys.has(card.entryKey);
+
     return (
       <div
-        className="aspect-[1/1.05] w-full rounded-lg border border-border p-4 sm:max-w-[calc((100%-2rem)/3)] sm:basis-[calc((100%-2rem)/3)]"
+        className="relative aspect-[1/1.05] w-full overflow-hidden rounded-lg border border-border p-4 sm:max-w-[calc((100%-2rem)/3)] sm:basis-[calc((100%-2rem)/3)]"
         ref={ref}
         style={{ opacity: isDragSource ? 0.65 : 1 }}
       >
-        <div className="mb-3 flex items-center justify-between gap-2">
-          <p className="font-semibold text-sm">
-            {label} {index + 1}
-          </p>
-          <div className="flex items-center gap-2">
-            {card.group ? (
-              <span className="rounded-full border border-border px-2 py-0.5 text-xs uppercase">
-                {card.group}
-              </span>
-            ) : null}
+        {isDeleteMode ? (
+          <>
             <button
-              aria-label="Drag card"
-              className="cursor-grab rounded-md border border-border p-1 text-muted-foreground active:cursor-grabbing"
-              ref={handleRef}
+              aria-label={`Toggle ${label.toLowerCase()} card ${index + 1} selection`}
+              className="absolute inset-0 z-10 bg-white/50"
+              onClick={() => onToggleCardSelected(card.entryKey, !isSelected)}
               type="button"
-            >
-              <GripVertical className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
+            />
+            <div className="absolute top-3 right-3 z-20">
+              <Checkbox
+                aria-label={`Select ${label.toLowerCase()} card ${index + 1}`}
+                checked={isSelected}
+                onCheckedChange={(checked) =>
+                  onToggleCardSelected(card.entryKey, checked === true)
+                }
+              />
+            </div>
+          </>
+        ) : null}
 
-        <div className="flex flex-col gap-3">
+        <div
+          className={`flex flex-col gap-3 ${isDeleteMode ? "pointer-events-none select-none" : ""}`}
+        >
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <p className="font-semibold text-sm">
+              {label} {index + 1}
+            </p>
+            <div className="flex items-center gap-2">
+              {card.group ? (
+                <span className="rounded-full border border-border px-2 py-0.5 text-xs uppercase">
+                  {card.group}
+                </span>
+              ) : null}
+              {!isDeleteMode ? (
+                <button
+                  aria-label="Drag card"
+                  className="cursor-grab rounded-md border border-border p-1 text-muted-foreground active:cursor-grabbing"
+                  ref={handleRef}
+                  type="button"
+                >
+                  <GripVertical className="h-4 w-4" />
+                </button>
+              ) : null}
+            </div>
+          </div>
+
           <div className="space-y-2">
             <p className="font-medium text-sm">Card Title</p>
             <form.Field name="title">
               {(field) => (
                 <Input
+                  disabled={isDeleteMode}
                   onChange={(event) => {
                     const value = event.target.value;
                     field.handleChange(value);
@@ -142,6 +180,7 @@ export function BoardOfTrusteesSection({
             <form.Field name="subtitle">
               {(field) => (
                 <Input
+                  disabled={isDeleteMode}
                   onChange={(event) => {
                     const value = event.target.value;
                     field.handleChange(value);
@@ -166,6 +205,7 @@ export function BoardOfTrusteesSection({
               <input
                 accept="image/*"
                 className="hidden"
+                disabled={isDeleteMode}
                 id={`board-image-${card.entryKey}`}
                 onChange={createImageSelectHandler(card.entryKey)}
                 type="file"
@@ -192,23 +232,75 @@ export function BoardOfTrusteesSection({
     title: string,
     cardLabel: string,
     groupCards: (typeof cards)[number][],
+    showDeleteActions = false,
   ) => (
     <section className="space-y-3">
       <div className="flex items-center justify-between gap-3">
         <p className="font-semibold text-muted-foreground text-sm uppercase tracking-wide">
           {title}
         </p>
-        <Button
-          onClick={() => onAddCard(group)}
-          size="sm"
-          type="button"
-          variant="outline"
-        >
-          Add Card
-        </Button>
+        <div className="flex flex-wrap items-center justify-end gap-2">
+          {showDeleteActions && isDeleteMode ? (
+            <>
+              <Button
+                disabled={isSectionActionDisabled || cards.length === 0}
+                onClick={onSelectAllCards}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Select All
+              </Button>
+              <Button
+                disabled={isSectionActionDisabled || selectedCount === 0}
+                onClick={onUnselectAllCards}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Unselect All
+              </Button>
+              <Button
+                disabled={isSectionActionDisabled}
+                onClick={onCancelDeleteMode}
+                size="sm"
+                type="button"
+                variant="ghost"
+              >
+                Cancel
+              </Button>
+            </>
+          ) : null}
+          <Button
+            disabled={isSectionActionDisabled || isDeleteMode}
+            onClick={() => onAddCard(group)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            Add Card
+          </Button>
+          {showDeleteActions ? (
+            <Button
+              disabled={
+                isSectionActionDisabled || (isDeleteMode && !hasSelectedCards)
+              }
+              onClick={onDeleteCardsClick}
+              size="sm"
+              type="button"
+              variant={isDeleteMode ? "destructive" : "outline"}
+            >
+              {isDeleteMode ? "Confirm Delete" : "Delete Cards"}
+            </Button>
+          ) : null}
+        </div>
       </div>
       <DragDropProvider
         onDragEnd={(event) => {
+          if (isDeleteMode) {
+            return;
+          }
+
           if (event.canceled || !isSortableOperation(event.operation)) {
             return;
           }
@@ -248,7 +340,7 @@ export function BoardOfTrusteesSection({
 
   return (
     <div className="space-y-6">
-      {renderSection("featured", "Featured", "Featured", featuredCards)}
+      {renderSection("featured", "Featured", "Featured", featuredCards, true)}
       {renderSection("officers", "Officers", "Officer", officerCards)}
       {renderSection("trustees", "Trustees", "Trustee", trusteeCards)}
       {renderSection("other", "Others", "Board Card", otherCards)}

--- a/src/app/admin/website-content/_components/sections/CompanyThrustsSection.tsx
+++ b/src/app/admin/website-content/_components/sections/CompanyThrustsSection.tsx
@@ -3,15 +3,26 @@
 import { useForm } from "@tanstack/react-form";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import type { CompanyThrustsSectionProps } from "../../_types/section-props";
+import type { CompanyThrustsSectionProps } from "../../_types/sectionProps";
 import { LucideIconPicker } from "../LucideIconPicker";
 import { MarkdownTextarea } from "../RichTextEditorField";
 
 export function CompanyThrustsSection({
   cards,
   placeholders,
+  isSectionActionDisabled,
+  isDeleteMode,
+  hasSelectedCards,
+  selectedCount,
+  selectedCardEntryKeys,
   onAddCard,
+  onDeleteCardsClick,
+  onCancelDeleteMode,
+  onSelectAllCards,
+  onUnselectAllCards,
+  onToggleCardSelected,
   onCardFieldChange,
 }: CompanyThrustsSectionProps) {
   const ThrustCardForm = ({
@@ -35,17 +46,41 @@ export function CompanyThrustsSection({
       form.setFieldValue("icon", card.icon);
     }, [card.icon, card.paragraph, card.title, form]);
 
-    return (
-      <div className="rounded-lg border border-border p-4">
-        <p className="mb-3 font-semibold text-sm">Thrust Card {index + 1}</p>
+    const isSelected = selectedCardEntryKeys.has(card.entryKey);
 
-        <div className="flex flex-col gap-4">
+    return (
+      <div className="relative overflow-hidden rounded-lg border border-border p-4">
+        {isDeleteMode ? (
+          <>
+            <button
+              aria-label={`Toggle thrust card ${index + 1} selection`}
+              className="absolute inset-0 z-10 bg-white/50"
+              onClick={() => onToggleCardSelected(card.entryKey, !isSelected)}
+              type="button"
+            />
+            <div className="absolute top-3 right-3 z-20">
+              <Checkbox
+                aria-label={`Select thrust card ${index + 1}`}
+                checked={isSelected}
+                onCheckedChange={(checked) =>
+                  onToggleCardSelected(card.entryKey, checked === true)
+                }
+              />
+            </div>
+          </>
+        ) : null}
+
+        <div
+          className={`flex flex-col gap-4 ${isDeleteMode ? "pointer-events-none select-none" : ""}`}
+        >
+          <p className="font-semibold text-sm">Thrust Card {index + 1}</p>
           <div className="space-y-4">
             <div className="flex flex-row gap-4">
               <div className="pr-1">
                 <form.Field name="icon">
                   {(field) => (
                     <LucideIconPicker
+                      disabled={isDeleteMode}
                       onSelect={(value) => {
                         field.handleChange(value);
                         onCardFieldChange(card.entryKey, "icon", value);
@@ -62,6 +97,7 @@ export function CompanyThrustsSection({
                   {(field) => (
                     <Input
                       className="truncate"
+                      disabled={isDeleteMode}
                       onChange={(event) => {
                         const value = event.target.value;
                         field.handleChange(value);
@@ -82,6 +118,7 @@ export function CompanyThrustsSection({
               <form.Field name="paragraph">
                 {(field) => (
                   <MarkdownTextarea
+                    disabled={isDeleteMode}
                     onChange={(value) => {
                       field.handleChange(value);
                       onCardFieldChange(card.entryKey, "paragraph", value);
@@ -103,9 +140,52 @@ export function CompanyThrustsSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={onAddCard} type="button" variant="outline">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {isDeleteMode ? (
+          <>
+            <Button
+              disabled={isSectionActionDisabled || cards.length === 0}
+              onClick={onSelectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Select All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled || selectedCount === 0}
+              onClick={onUnselectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Unselect All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled}
+              onClick={onCancelDeleteMode}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </>
+        ) : null}
+        <Button
+          disabled={isSectionActionDisabled || isDeleteMode}
+          onClick={onAddCard}
+          type="button"
+          variant="outline"
+        >
           Add Card
+        </Button>
+        <Button
+          disabled={
+            isSectionActionDisabled || (isDeleteMode && !hasSelectedCards)
+          }
+          onClick={onDeleteCardsClick}
+          type="button"
+          variant={isDeleteMode ? "destructive" : "outline"}
+        >
+          {isDeleteMode ? "Confirm Delete" : "Delete Cards"}
         </Button>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/app/admin/website-content/_components/sections/GoalsSection.tsx
+++ b/src/app/admin/website-content/_components/sections/GoalsSection.tsx
@@ -3,15 +3,26 @@
 import { useForm } from "@tanstack/react-form";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import type { GoalsSectionProps } from "../../_types/section-props";
+import type { GoalsSectionProps } from "../../_types/sectionProps";
 import { LucideIconPicker } from "../LucideIconPicker";
 import { MarkdownTextarea } from "../RichTextEditorField";
 
 export function GoalsSection({
   cards,
   placeholders,
+  isSectionActionDisabled,
+  isDeleteMode,
+  hasSelectedCards,
+  selectedCount,
+  selectedCardEntryKeys,
   onAddCard,
+  onDeleteCardsClick,
+  onCancelDeleteMode,
+  onSelectAllCards,
+  onUnselectAllCards,
+  onToggleCardSelected,
   onCardFieldChange,
 }: GoalsSectionProps) {
   const GoalCardForm = ({
@@ -35,17 +46,41 @@ export function GoalsSection({
       form.setFieldValue("icon", card.icon);
     }, [card.icon, card.paragraph, card.title, form]);
 
-    return (
-      <div className="rounded-lg border border-border p-4">
-        <p className="mb-3 font-semibold text-sm">Goal Card {index + 1}</p>
+    const isSelected = selectedCardEntryKeys.has(card.entryKey);
 
-        <div className="flex flex-col gap-4">
+    return (
+      <div className="relative overflow-hidden rounded-lg border border-border p-4">
+        {isDeleteMode ? (
+          <>
+            <button
+              aria-label={`Toggle goal card ${index + 1} selection`}
+              className="absolute inset-0 z-10 bg-white/50"
+              onClick={() => onToggleCardSelected(card.entryKey, !isSelected)}
+              type="button"
+            />
+            <div className="absolute top-3 right-3 z-20">
+              <Checkbox
+                aria-label={`Select goal card ${index + 1}`}
+                checked={isSelected}
+                onCheckedChange={(checked) =>
+                  onToggleCardSelected(card.entryKey, checked === true)
+                }
+              />
+            </div>
+          </>
+        ) : null}
+
+        <div
+          className={`flex flex-col gap-4 ${isDeleteMode ? "pointer-events-none select-none" : ""}`}
+        >
+          <p className="font-semibold text-sm">Goal Card {index + 1}</p>
           <div className="space-y-4">
             <div className="flex flex-row gap-4">
               <div className="pr-1">
                 <form.Field name="icon">
                   {(field) => (
                     <LucideIconPicker
+                      disabled={isDeleteMode}
                       onSelect={(value) => {
                         field.handleChange(value);
                         onCardFieldChange(card.entryKey, "icon", value);
@@ -62,6 +97,7 @@ export function GoalsSection({
                   {(field) => (
                     <Input
                       className="truncate"
+                      disabled={isDeleteMode}
                       onChange={(event) => {
                         const value = event.target.value;
                         field.handleChange(value);
@@ -82,6 +118,7 @@ export function GoalsSection({
               <form.Field name="paragraph">
                 {(field) => (
                   <MarkdownTextarea
+                    disabled={isDeleteMode}
                     onChange={(value) => {
                       field.handleChange(value);
                       onCardFieldChange(card.entryKey, "paragraph", value);
@@ -103,9 +140,52 @@ export function GoalsSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={onAddCard} type="button" variant="outline">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {isDeleteMode ? (
+          <>
+            <Button
+              disabled={isSectionActionDisabled || cards.length === 0}
+              onClick={onSelectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Select All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled || selectedCount === 0}
+              onClick={onUnselectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Unselect All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled}
+              onClick={onCancelDeleteMode}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </>
+        ) : null}
+        <Button
+          disabled={isSectionActionDisabled || isDeleteMode}
+          onClick={onAddCard}
+          type="button"
+          variant="outline"
+        >
           Add Card
+        </Button>
+        <Button
+          disabled={
+            isSectionActionDisabled || (isDeleteMode && !hasSelectedCards)
+          }
+          onClick={onDeleteCardsClick}
+          type="button"
+          variant={isDeleteMode ? "destructive" : "outline"}
+        >
+          {isDeleteMode ? "Confirm Delete" : "Delete Cards"}
         </Button>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/app/admin/website-content/_components/sections/LandingBenefitsSection.tsx
+++ b/src/app/admin/website-content/_components/sections/LandingBenefitsSection.tsx
@@ -3,15 +3,26 @@
 import { useForm } from "@tanstack/react-form";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import type { LandingBenefitsSectionProps } from "../../_types/section-props";
+import type { LandingBenefitsSectionProps } from "../../_types/sectionProps";
 import { LucideIconPicker } from "../LucideIconPicker";
 import { MarkdownTextarea } from "../RichTextEditorField";
 
 export function LandingBenefitsSection({
   cards,
   placeholders,
+  isSectionActionDisabled,
+  isDeleteMode,
+  hasSelectedCards,
+  selectedCount,
+  selectedCardEntryKeys,
   onAddCard,
+  onDeleteCardsClick,
+  onCancelDeleteMode,
+  onSelectAllCards,
+  onUnselectAllCards,
+  onToggleCardSelected,
   onCardFieldChange,
 }: LandingBenefitsSectionProps) {
   const BenefitCardForm = ({
@@ -35,17 +46,41 @@ export function LandingBenefitsSection({
       form.setFieldValue("icon", card.icon);
     }, [card.icon, card.paragraph, card.title, form]);
 
-    return (
-      <div className="rounded-lg border border-border p-4">
-        <p className="mb-3 font-semibold text-sm">Benefit Card {index + 1}</p>
+    const isSelected = selectedCardEntryKeys.has(card.entryKey);
 
-        <div className="flex flex-col gap-4">
+    return (
+      <div className="relative overflow-hidden rounded-lg border border-border p-4">
+        {isDeleteMode ? (
+          <>
+            <button
+              aria-label={`Toggle benefit card ${index + 1} selection`}
+              className="absolute inset-0 z-10 bg-white/50"
+              onClick={() => onToggleCardSelected(card.entryKey, !isSelected)}
+              type="button"
+            />
+            <div className="absolute top-3 right-3 z-20">
+              <Checkbox
+                aria-label={`Select benefit card ${index + 1}`}
+                checked={isSelected}
+                onCheckedChange={(checked) =>
+                  onToggleCardSelected(card.entryKey, checked === true)
+                }
+              />
+            </div>
+          </>
+        ) : null}
+
+        <div
+          className={`flex flex-col gap-4 ${isDeleteMode ? "pointer-events-none select-none" : ""}`}
+        >
+          <p className="font-semibold text-sm">Benefit Card {index + 1}</p>
           <div className="space-y-4">
             <div className="flex flex-row gap-4">
               <div className="pr-1">
                 <form.Field name="icon">
                   {(field) => (
                     <LucideIconPicker
+                      disabled={isDeleteMode}
                       onSelect={(value) => {
                         field.handleChange(value);
                         onCardFieldChange(card.entryKey, "icon", value);
@@ -62,6 +97,7 @@ export function LandingBenefitsSection({
                   {(field) => (
                     <Input
                       className="truncate"
+                      disabled={isDeleteMode}
                       onChange={(event) => {
                         const value = event.target.value;
                         field.handleChange(value);
@@ -80,6 +116,7 @@ export function LandingBenefitsSection({
               <form.Field name="paragraph">
                 {(field) => (
                   <MarkdownTextarea
+                    disabled={isDeleteMode}
                     onChange={(value) => {
                       field.handleChange(value);
                       onCardFieldChange(card.entryKey, "paragraph", value);
@@ -101,9 +138,52 @@ export function LandingBenefitsSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={onAddCard} type="button" variant="outline">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {isDeleteMode ? (
+          <>
+            <Button
+              disabled={isSectionActionDisabled || cards.length === 0}
+              onClick={onSelectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Select All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled || selectedCount === 0}
+              onClick={onUnselectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Unselect All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled}
+              onClick={onCancelDeleteMode}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </>
+        ) : null}
+        <Button
+          disabled={isSectionActionDisabled || isDeleteMode}
+          onClick={onAddCard}
+          type="button"
+          variant="outline"
+        >
           Add Card
+        </Button>
+        <Button
+          disabled={
+            isSectionActionDisabled || (isDeleteMode && !hasSelectedCards)
+          }
+          onClick={onDeleteCardsClick}
+          type="button"
+          variant={isDeleteMode ? "destructive" : "outline"}
+        >
+          {isDeleteMode ? "Confirm Delete" : "Delete Cards"}
         </Button>
       </div>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">

--- a/src/app/admin/website-content/_components/sections/SecretariatSection.tsx
+++ b/src/app/admin/website-content/_components/sections/SecretariatSection.tsx
@@ -7,15 +7,26 @@ import { GripVertical } from "lucide-react";
 import Image from "next/image";
 import { useEffect } from "react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { reorderInList } from "../../_hooks/reorderInList";
 import { usePersonalImageUpload } from "../../_hooks/usePersonalImageUpload";
-import type { SecretariatSectionProps } from "../../_types/section-props";
+import type { SecretariatSectionProps } from "../../_types/sectionProps";
 
 export function SecretariatSection({
   cards,
   placeholders,
+  isSectionActionDisabled,
+  isDeleteMode,
+  hasSelectedCards,
+  selectedCount,
+  selectedCardEntryKeys,
   onAddCard,
+  onDeleteCardsClick,
+  onCancelDeleteMode,
+  onSelectAllCards,
+  onUnselectAllCards,
+  onToggleCardSelected,
   onCardFieldChange,
   onCardsReorder,
 }: SecretariatSectionProps) {
@@ -51,30 +62,59 @@ export function SecretariatSection({
       form.setFieldValue("subtitle", card.subtitle);
     }, [card.subtitle, card.title, form]);
 
+    const isSelected = selectedCardEntryKeys.has(card.entryKey);
+
     return (
       <div
-        className="aspect-[1/1.05] rounded-lg border border-border p-4"
+        className="relative aspect-[1/1.05] overflow-hidden rounded-lg border border-border p-4"
         ref={ref}
         style={{ opacity: isDragSource ? 0.65 : 1 }}
       >
-        <div className="mb-3 flex items-center justify-between gap-2">
-          <p className="font-semibold text-sm">Secretariat Card {index + 1}</p>
-          <button
-            aria-label="Drag card"
-            className="cursor-grab rounded-md border border-border p-1 text-muted-foreground active:cursor-grabbing"
-            ref={handleRef}
-            type="button"
-          >
-            <GripVertical className="h-4 w-4" />
-          </button>
-        </div>
+        {isDeleteMode ? (
+          <>
+            <button
+              aria-label={`Toggle secretariat card ${index + 1} selection`}
+              className="absolute inset-0 z-10 bg-white/50"
+              onClick={() => onToggleCardSelected(card.entryKey, !isSelected)}
+              type="button"
+            />
+            <div className="absolute top-3 right-3 z-20">
+              <Checkbox
+                aria-label={`Select secretariat card ${index + 1}`}
+                checked={isSelected}
+                onCheckedChange={(checked) =>
+                  onToggleCardSelected(card.entryKey, checked === true)
+                }
+              />
+            </div>
+          </>
+        ) : null}
 
-        <div className="flex flex-col gap-3">
+        <div
+          className={`flex flex-col gap-3 ${isDeleteMode ? "pointer-events-none select-none" : ""}`}
+        >
+          <div className="mb-3 flex items-center justify-between gap-2">
+            <p className="font-semibold text-sm">
+              Secretariat Card {index + 1}
+            </p>
+            {!isDeleteMode ? (
+              <button
+                aria-label="Drag card"
+                className="cursor-grab rounded-md border border-border p-1 text-muted-foreground active:cursor-grabbing"
+                ref={handleRef}
+                type="button"
+              >
+                <GripVertical className="h-4 w-4" />
+              </button>
+            ) : null}
+          </div>
+
           <div className="space-y-2">
             <p className="font-medium text-sm">Card Title</p>
             <form.Field name="title">
               {(field) => (
                 <Input
+                  disabled={isDeleteMode}
                   onChange={(event) => {
                     const value = event.target.value;
                     field.handleChange(value);
@@ -91,6 +131,7 @@ export function SecretariatSection({
             <form.Field name="subtitle">
               {(field) => (
                 <Input
+                  disabled={isDeleteMode}
                   onChange={(event) => {
                     const value = event.target.value;
                     field.handleChange(value);
@@ -117,6 +158,7 @@ export function SecretariatSection({
               <input
                 accept="image/*"
                 className="hidden"
+                disabled={isDeleteMode}
                 id={`secretariat-image-${card.entryKey}`}
                 onChange={createImageSelectHandler(card.entryKey)}
                 type="file"
@@ -140,13 +182,60 @@ export function SecretariatSection({
 
   return (
     <div className="space-y-4">
-      <div className="flex justify-end">
-        <Button onClick={onAddCard} type="button" variant="outline">
+      <div className="flex flex-wrap items-center justify-end gap-2">
+        {isDeleteMode ? (
+          <>
+            <Button
+              disabled={isSectionActionDisabled || cards.length === 0}
+              onClick={onSelectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Select All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled || selectedCount === 0}
+              onClick={onUnselectAllCards}
+              type="button"
+              variant="ghost"
+            >
+              Unselect All
+            </Button>
+            <Button
+              disabled={isSectionActionDisabled}
+              onClick={onCancelDeleteMode}
+              type="button"
+              variant="ghost"
+            >
+              Cancel
+            </Button>
+          </>
+        ) : null}
+        <Button
+          disabled={isSectionActionDisabled || isDeleteMode}
+          onClick={onAddCard}
+          type="button"
+          variant="outline"
+        >
           Add Card
+        </Button>
+        <Button
+          disabled={
+            isSectionActionDisabled || (isDeleteMode && !hasSelectedCards)
+          }
+          onClick={onDeleteCardsClick}
+          type="button"
+          variant={isDeleteMode ? "destructive" : "outline"}
+        >
+          {isDeleteMode ? "Confirm Delete" : "Delete Cards"}
         </Button>
       </div>
       <DragDropProvider
         onDragEnd={(event) => {
+          if (isDeleteMode) {
+            return;
+          }
+
           if (event.canceled || !isSortableOperation(event.operation)) {
             return;
           }

--- a/src/app/admin/website-content/_components/sections/VisionMissionSection.tsx
+++ b/src/app/admin/website-content/_components/sections/VisionMissionSection.tsx
@@ -2,7 +2,7 @@
 
 import { useForm } from "@tanstack/react-form";
 import { useEffect } from "react";
-import type { VisionMissionSectionProps } from "../../_types/section-props";
+import type { VisionMissionSectionProps } from "../../_types/sectionProps";
 import { MarkdownTextarea } from "../RichTextEditorField";
 
 export function VisionMissionSection({

--- a/src/app/admin/website-content/_hooks/useWebsiteContentEditor.ts
+++ b/src/app/admin/website-content/_hooks/useWebsiteContentEditor.ts
@@ -5,6 +5,10 @@ import { toast } from "sonner";
 import { useAction } from "@/hooks/useAction";
 import tryCatch from "@/lib/server/tryCatch";
 import { getWebsiteContentSection } from "@/server/website-content/mutations/getWebsiteContentSection";
+import {
+  getWebsiteContentSectionsSummary,
+  type WebsiteContentSectionsSummary,
+} from "@/server/website-content/mutations/getWebsiteContentSectionsSummary";
 import { saveWebsiteContentSection } from "@/server/website-content/mutations/saveWebsiteContentSection";
 import type {
   WebsiteContentCardState,
@@ -29,6 +33,10 @@ export function useWebsiteContentEditor(
 ) {
   const [form, setForm] = useState<WebsiteContentFormState>(emptyForm);
   const [cards, setCards] = useState<WebsiteContentCardState[]>([]);
+  const [isDeleteMode, setIsDeleteMode] = useState(false);
+  const [selectedCardEntryKeys, setSelectedCardEntryKeys] = useState<
+    Set<string>
+  >(() => new Set());
   const [cachedSectionContentBySection, setCachedSectionContentBySection] =
     useState<
       Partial<
@@ -47,6 +55,41 @@ export function useWebsiteContentEditor(
   const [updatedAtBySection, setUpdatedAtBySection] = useState<
     Partial<Record<WebsiteContentSection, string>>
   >({});
+  const [cardCountBySection, setCardCountBySection] = useState<
+    Partial<Record<WebsiteContentSection, number>>
+  >({});
+  const [hasLoadedSectionSummaries, setHasLoadedSectionSummaries] =
+    useState(false);
+
+  const { execute: loadSectionSummaries } = useAction(
+    tryCatch(getWebsiteContentSectionsSummary),
+    {
+      onSuccess: (summary: WebsiteContentSectionsSummary) => {
+        const nextUpdatedAtBySection: Partial<
+          Record<WebsiteContentSection, string>
+        > = {};
+        const nextCardCountBySection: Partial<
+          Record<WebsiteContentSection, number>
+        > = {};
+
+        for (const [section, sectionSummary] of Object.entries(summary)) {
+          const typedSection = section as WebsiteContentSection;
+          if (sectionSummary.updatedAt) {
+            nextUpdatedAtBySection[typedSection] = sectionSummary.updatedAt;
+          }
+          nextCardCountBySection[typedSection] = sectionSummary.cardCount;
+        }
+
+        setUpdatedAtBySection(nextUpdatedAtBySection);
+        setCardCountBySection(nextCardCountBySection);
+        setHasLoadedSectionSummaries(true);
+      },
+      onError: (error) => {
+        toast.error(error);
+        setHasLoadedSectionSummaries(true);
+      },
+    },
+  );
 
   const { execute: loadSection, isPending: isLoadingSection } = useAction(
     tryCatch(getWebsiteContentSection),
@@ -73,6 +116,12 @@ export function useWebsiteContentEditor(
             [activeSection]: data.updatedAt,
           }));
         }
+        if (activeSection) {
+          setCardCountBySection((prev) => ({
+            ...prev,
+            [activeSection]: data.cards.length,
+          }));
+        }
       },
       onError: (error) => {
         toast.error(error);
@@ -91,6 +140,7 @@ export function useWebsiteContentEditor(
           }));
           await loadSection(activeSection);
         }
+        await loadSectionSummaries();
         toast.success("Website content saved");
       },
       onError: (error) => {
@@ -100,6 +150,13 @@ export function useWebsiteContentEditor(
   );
 
   useEffect(() => {
+    void loadSectionSummaries();
+  }, [loadSectionSummaries]);
+
+  useEffect(() => {
+    setIsDeleteMode(false);
+    setSelectedCardEntryKeys(new Set());
+
     if (!activeSection) {
       return;
     }
@@ -234,6 +291,68 @@ export function useWebsiteContentEditor(
     });
   };
 
+  const enterDeleteMode = () => {
+    setIsDeleteMode(true);
+  };
+
+  const cancelDeleteMode = () => {
+    setIsDeleteMode(false);
+    setSelectedCardEntryKeys(new Set());
+  };
+
+  const clearCardSelection = () => {
+    setSelectedCardEntryKeys(new Set());
+  };
+
+  const selectAllCards = () => {
+    setSelectedCardEntryKeys(new Set(cards.map((card) => card.entryKey)));
+  };
+
+  const unselectAllCards = () => {
+    setSelectedCardEntryKeys(new Set());
+  };
+
+  const toggleCardSelected = (entryKey: string, checked: boolean) => {
+    setSelectedCardEntryKeys((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(entryKey);
+      } else {
+        next.delete(entryKey);
+      }
+      return next;
+    });
+  };
+
+  const deleteSelectedCards = () => {
+    if (!activeSection || selectedCardEntryKeys.size === 0) {
+      return;
+    }
+
+    setCards((prev) => {
+      const filtered = prev.filter(
+        (card) => !selectedCardEntryKeys.has(card.entryKey),
+      );
+      const nextCards = filtered.map((card, index) => ({
+        ...card,
+        cardPlacement: String(index + 1),
+      }));
+
+      setCachedSectionContentBySection((cachePrev) => ({
+        ...cachePrev,
+        [activeSection]: {
+          form: cachePrev[activeSection]?.form ?? form,
+          cards: nextCards,
+        },
+      }));
+
+      return nextCards;
+    });
+
+    setSelectedCardEntryKeys(new Set());
+    setIsDeleteMode(false);
+  };
+
   const save = async () => {
     if (!activeSection) {
       return;
@@ -253,6 +372,15 @@ export function useWebsiteContentEditor(
     setCardField,
     replaceCards,
     addCard,
+    isDeleteMode,
+    selectedCardEntryKeys,
+    enterDeleteMode,
+    cancelDeleteMode,
+    clearCardSelection,
+    selectAllCards,
+    unselectAllCards,
+    toggleCardSelected,
+    deleteSelectedCards,
     save,
     isSavingSection,
     isLoadingSection,
@@ -260,5 +388,7 @@ export function useWebsiteContentEditor(
     sectionUpdatedAt,
     placeholdersBySection,
     updatedAtBySection,
+    cardCountBySection,
+    hasLoadedSectionSummaries,
   };
 }

--- a/src/app/admin/website-content/_hooks/useWebsiteContentEditor.ts
+++ b/src/app/admin/website-content/_hooks/useWebsiteContentEditor.ts
@@ -4,12 +4,12 @@ import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { useAction } from "@/hooks/useAction";
 import tryCatch from "@/lib/server/tryCatch";
-import { getWebsiteContentSection } from "@/server/website-content/mutations/getWebsiteContentSection";
+import { saveWebsiteContentSection } from "@/server/website-content/mutations/saveWebsiteContentSection";
+import { getWebsiteContentSection } from "@/server/website-content/queries/getWebsiteContentSection";
 import {
   getWebsiteContentSectionsSummary,
   type WebsiteContentSectionsSummary,
-} from "@/server/website-content/mutations/getWebsiteContentSectionsSummary";
-import { saveWebsiteContentSection } from "@/server/website-content/mutations/saveWebsiteContentSection";
+} from "@/server/website-content/queries/getWebsiteContentSectionsSummary";
 import type {
   WebsiteContentCardState,
   WebsiteContentFormState,
@@ -61,8 +61,21 @@ export function useWebsiteContentEditor(
   const [hasLoadedSectionSummaries, setHasLoadedSectionSummaries] =
     useState(false);
 
+  const getWebsiteContentSectionsSummaryAction = useMemo(
+    () => tryCatch(getWebsiteContentSectionsSummary),
+    [],
+  );
+  const getWebsiteContentSectionAction = useMemo(
+    () => tryCatch(getWebsiteContentSection),
+    [],
+  );
+  const saveWebsiteContentSectionAction = useMemo(
+    () => tryCatch(saveWebsiteContentSection),
+    [],
+  );
+
   const { execute: loadSectionSummaries } = useAction(
-    tryCatch(getWebsiteContentSectionsSummary),
+    getWebsiteContentSectionsSummaryAction,
     {
       onSuccess: (summary: WebsiteContentSectionsSummary) => {
         const nextUpdatedAtBySection: Partial<
@@ -92,7 +105,7 @@ export function useWebsiteContentEditor(
   );
 
   const { execute: loadSection, isPending: isLoadingSection } = useAction(
-    tryCatch(getWebsiteContentSection),
+    getWebsiteContentSectionAction,
     {
       onSuccess: (data: WebsiteContentSectionData) => {
         setForm(data.form);
@@ -130,7 +143,7 @@ export function useWebsiteContentEditor(
   );
 
   const { execute: saveSection, isPending: isSavingSection } = useAction(
-    tryCatch(saveWebsiteContentSection),
+    saveWebsiteContentSectionAction,
     {
       onSuccess: async (result: { updatedAt: string }) => {
         if (activeSection) {

--- a/src/app/admin/website-content/_types/sectionProps.ts
+++ b/src/app/admin/website-content/_types/sectionProps.ts
@@ -25,7 +25,17 @@ export interface VisionMissionSectionProps {
 export interface GoalsSectionProps {
   cards: WebsiteContentCardState[];
   placeholders: WebsiteContentFormState;
+  isSectionActionDisabled: boolean;
   onAddCard: () => void;
+  isDeleteMode: boolean;
+  hasSelectedCards: boolean;
+  selectedCount: number;
+  selectedCardEntryKeys: Set<string>;
+  onDeleteCardsClick: () => void;
+  onCancelDeleteMode: () => void;
+  onSelectAllCards: () => void;
+  onUnselectAllCards: () => void;
+  onToggleCardSelected: (entryKey: string, checked: boolean) => void;
   onCardFieldChange: (
     entryKey: string,
     field: keyof WebsiteContentCardState,
@@ -36,7 +46,17 @@ export interface GoalsSectionProps {
 export interface CompanyThrustsSectionProps {
   cards: WebsiteContentCardState[];
   placeholders: WebsiteContentFormState;
+  isSectionActionDisabled: boolean;
   onAddCard: () => void;
+  isDeleteMode: boolean;
+  hasSelectedCards: boolean;
+  selectedCount: number;
+  selectedCardEntryKeys: Set<string>;
+  onDeleteCardsClick: () => void;
+  onCancelDeleteMode: () => void;
+  onSelectAllCards: () => void;
+  onUnselectAllCards: () => void;
+  onToggleCardSelected: (entryKey: string, checked: boolean) => void;
   onCardFieldChange: (
     entryKey: string,
     field: keyof WebsiteContentCardState,
@@ -47,7 +67,17 @@ export interface CompanyThrustsSectionProps {
 export interface BoardOfTrusteesSectionProps {
   cards: WebsiteContentCardState[];
   placeholders: WebsiteContentFormState;
+  isSectionActionDisabled: boolean;
   onAddCard: (group: "featured" | "officers" | "trustees" | "other") => void;
+  isDeleteMode: boolean;
+  hasSelectedCards: boolean;
+  selectedCount: number;
+  selectedCardEntryKeys: Set<string>;
+  onDeleteCardsClick: () => void;
+  onCancelDeleteMode: () => void;
+  onSelectAllCards: () => void;
+  onUnselectAllCards: () => void;
+  onToggleCardSelected: (entryKey: string, checked: boolean) => void;
   onCardFieldChange: (
     entryKey: string,
     field: keyof WebsiteContentCardState,
@@ -59,7 +89,17 @@ export interface BoardOfTrusteesSectionProps {
 export interface SecretariatSectionProps {
   cards: WebsiteContentCardState[];
   placeholders: WebsiteContentFormState;
+  isSectionActionDisabled: boolean;
   onAddCard: () => void;
+  isDeleteMode: boolean;
+  hasSelectedCards: boolean;
+  selectedCount: number;
+  selectedCardEntryKeys: Set<string>;
+  onDeleteCardsClick: () => void;
+  onCancelDeleteMode: () => void;
+  onSelectAllCards: () => void;
+  onUnselectAllCards: () => void;
+  onToggleCardSelected: (entryKey: string, checked: boolean) => void;
   onCardFieldChange: (
     entryKey: string,
     field: keyof WebsiteContentCardState,
@@ -71,7 +111,17 @@ export interface SecretariatSectionProps {
 export interface LandingBenefitsSectionProps {
   cards: WebsiteContentCardState[];
   placeholders: WebsiteContentFormState;
+  isSectionActionDisabled: boolean;
   onAddCard: () => void;
+  isDeleteMode: boolean;
+  hasSelectedCards: boolean;
+  selectedCount: number;
+  selectedCardEntryKeys: Set<string>;
+  onDeleteCardsClick: () => void;
+  onCancelDeleteMode: () => void;
+  onSelectAllCards: () => void;
+  onUnselectAllCards: () => void;
+  onToggleCardSelected: (entryKey: string, checked: boolean) => void;
   onCardFieldChange: (
     entryKey: string,
     field: keyof WebsiteContentCardState,

--- a/src/app/auth/(login)/_components/forms/LoginForm.tsx
+++ b/src/app/auth/(login)/_components/forms/LoginForm.tsx
@@ -23,7 +23,7 @@ export const LoginForm = () => {
 
   return (
     <Card className="w-full max-w-[400px]">
-      <form className="space-y-4" onSubmit={handleSubmit}>
+      <form className="space-y-4" method="post" onSubmit={handleSubmit}>
         <CardHeader>Login</CardHeader>
         <CardContent>
           <FieldGroup>

--- a/src/server/website-content/mutations/getWebsiteContentSectionsSummary.ts
+++ b/src/server/website-content/mutations/getWebsiteContentSectionsSummary.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import { createActionClient } from "@/lib/supabase/server";
+import type { WebsiteContentSection } from "../types";
+
+type WebsiteContentSectionSummary = {
+  updatedAt: string | null;
+  cardCount: number;
+};
+
+export type WebsiteContentSectionsSummary = Record<
+  WebsiteContentSection,
+  WebsiteContentSectionSummary
+>;
+
+type WebsiteContentSummaryRow = {
+  section: WebsiteContentSection;
+  entryKey: string;
+  updatedAt: string;
+};
+
+const SECTION_KEYS: WebsiteContentSection[] = [
+  "vision_mission",
+  "goals",
+  "company_thrusts",
+  "board_of_trustees",
+  "secretariat",
+  "landing_page_benefits",
+];
+
+function createEmptySummary(): WebsiteContentSectionsSummary {
+  return {
+    vision_mission: { updatedAt: null, cardCount: 0 },
+    goals: { updatedAt: null, cardCount: 0 },
+    company_thrusts: { updatedAt: null, cardCount: 0 },
+    board_of_trustees: { updatedAt: null, cardCount: 0 },
+    secretariat: { updatedAt: null, cardCount: 0 },
+    landing_page_benefits: { updatedAt: null, cardCount: 0 },
+  };
+}
+
+export async function getWebsiteContentSectionsSummary(): Promise<WebsiteContentSectionsSummary> {
+  const supabase = await createActionClient();
+
+  const { data, error } = await supabase
+    .from("WebsiteContent")
+    .select("section, entryKey, updatedAt")
+    .eq("isActive", true);
+
+  if (error) {
+    throw new Error(
+      `Failed to fetch website content summary: ${error.message}`,
+    );
+  }
+
+  const summary = createEmptySummary();
+  const entryKeysBySection = new Map<WebsiteContentSection, Set<string>>(
+    SECTION_KEYS.map((section) => [section, new Set()]),
+  );
+
+  const rows = (
+    (data as unknown as WebsiteContentSummaryRow[] | null) ?? []
+  ).filter(Boolean);
+
+  for (const row of rows) {
+    if (!SECTION_KEYS.includes(row.section)) {
+      continue;
+    }
+
+    const sectionSummary = summary[row.section];
+    if (!sectionSummary.updatedAt || row.updatedAt > sectionSummary.updatedAt) {
+      sectionSummary.updatedAt = row.updatedAt;
+    }
+
+    const entryKeys = entryKeysBySection.get(row.section);
+    if (entryKeys) {
+      entryKeys.add(row.entryKey);
+      sectionSummary.cardCount = entryKeys.size;
+    }
+  }
+
+  return summary;
+}

--- a/src/server/website-content/mutations/saveWebsiteContentSection.ts
+++ b/src/server/website-content/mutations/saveWebsiteContentSection.ts
@@ -8,7 +8,7 @@ import type {
   UpsertWebsiteContentRowInput,
 } from "../types";
 import {
-  deactivateWebsiteContentEntriesBySection,
+  deleteWebsiteContentEntriesBySection,
   upsertWebsiteContentRows,
 } from "./upsertWebsiteContentRow";
 
@@ -93,12 +93,9 @@ export async function saveWebsiteContentSection(
     }
   }
 
-  await deactivateWebsiteContentEntriesBySection(
-    parsed.section,
-    retainedEntryKeys,
-  );
-
   await upsertWebsiteContentRows(rowsToUpsert);
+
+  await deleteWebsiteContentEntriesBySection(parsed.section, retainedEntryKeys);
 
   revalidatePath("/", "page");
   revalidatePath("/about", "page");

--- a/src/server/website-content/mutations/saveWebsiteContentSection.ts
+++ b/src/server/website-content/mutations/saveWebsiteContentSection.ts
@@ -7,7 +7,10 @@ import type {
   SaveWebsiteContentSectionInput,
   UpsertWebsiteContentRowInput,
 } from "../types";
-import { upsertWebsiteContentRows } from "./upsertWebsiteContentRow";
+import {
+  deactivateWebsiteContentEntriesBySection,
+  upsertWebsiteContentRows,
+} from "./upsertWebsiteContentRow";
 
 const WEBSITE_CONTENT_SECTION_TAG_BY_SECTION = {
   vision_mission: CACHE_TAGS.websiteContent.section.visionMission,
@@ -23,8 +26,11 @@ export async function saveWebsiteContentSection(
 ): Promise<{ updatedAt: string }> {
   const parsed = saveWebsiteContentSectionSchema.parse(input);
   const rowsToUpsert: UpsertWebsiteContentRowInput[] = [];
+  const retainedEntryKeys: string[] = [];
 
   if (parsed.section === "vision_mission") {
+    retainedEntryKeys.push("vision", "mission");
+
     rowsToUpsert.push({
       section: parsed.section,
       entryKey: "vision",
@@ -40,6 +46,8 @@ export async function saveWebsiteContentSection(
     });
   } else {
     for (const card of parsed.cards) {
+      retainedEntryKeys.push(card.entryKey);
+
       const placementValue = card.cardPlacement
         ? Number(card.cardPlacement)
         : null;
@@ -84,6 +92,11 @@ export async function saveWebsiteContentSection(
       });
     }
   }
+
+  await deactivateWebsiteContentEntriesBySection(
+    parsed.section,
+    retainedEntryKeys,
+  );
 
   await upsertWebsiteContentRows(rowsToUpsert);
 

--- a/src/server/website-content/mutations/upsertWebsiteContentRow.ts
+++ b/src/server/website-content/mutations/upsertWebsiteContentRow.ts
@@ -1,7 +1,10 @@
 "use server";
 
 import { createActionClient } from "@/lib/supabase/server";
-import type { UpsertWebsiteContentRowInput } from "../types";
+import type {
+  UpsertWebsiteContentRowInput,
+  WebsiteContentSection,
+} from "../types";
 
 type WebsiteContentSupabaseClient = Awaited<
   ReturnType<typeof createActionClient>
@@ -49,4 +52,45 @@ export async function upsertWebsiteContentRows(
   await Promise.all(
     inputs.map((input) => executeUpsertWebsiteContentRow(supabase, input)),
   );
+}
+
+export async function deactivateWebsiteContentEntriesBySection(
+  section: WebsiteContentSection,
+  retainedEntryKeys: string[],
+) {
+  const supabase = await createActionClient();
+
+  const { data, error } = await supabase
+    .from("WebsiteContent")
+    .select("entryKey")
+    .eq("section", section)
+    .eq("isActive", true);
+
+  if (error) {
+    throw new Error(
+      `Failed to check existing website content rows: ${error.message}`,
+    );
+  }
+
+  const retained = new Set(retainedEntryKeys);
+  const entryKeysToDeactivate = Array.from(
+    new Set((data ?? []).map((row) => row.entryKey).filter(Boolean)),
+  ).filter((entryKey) => !retained.has(entryKey));
+
+  if (entryKeysToDeactivate.length === 0) {
+    return;
+  }
+
+  const { error: deactivateError } = await supabase
+    .from("WebsiteContent")
+    .update({ isActive: false })
+    .eq("section", section)
+    .eq("isActive", true)
+    .in("entryKey", entryKeysToDeactivate);
+
+  if (deactivateError) {
+    throw new Error(
+      `Failed to deactivate removed website content rows: ${deactivateError.message}`,
+    );
+  }
 }

--- a/src/server/website-content/mutations/upsertWebsiteContentRow.ts
+++ b/src/server/website-content/mutations/upsertWebsiteContentRow.ts
@@ -54,7 +54,7 @@ export async function upsertWebsiteContentRows(
   );
 }
 
-export async function deactivateWebsiteContentEntriesBySection(
+export async function deleteWebsiteContentEntriesBySection(
   section: WebsiteContentSection,
   retainedEntryKeys: string[],
 ) {
@@ -73,24 +73,24 @@ export async function deactivateWebsiteContentEntriesBySection(
   }
 
   const retained = new Set(retainedEntryKeys);
-  const entryKeysToDeactivate = Array.from(
+  const entryKeysToDelete = Array.from(
     new Set((data ?? []).map((row) => row.entryKey).filter(Boolean)),
   ).filter((entryKey) => !retained.has(entryKey));
 
-  if (entryKeysToDeactivate.length === 0) {
+  if (entryKeysToDelete.length === 0) {
     return;
   }
 
-  const { error: deactivateError } = await supabase
+  const { error: deleteError } = await supabase
     .from("WebsiteContent")
     .update({ isActive: false })
     .eq("section", section)
     .eq("isActive", true)
-    .in("entryKey", entryKeysToDeactivate);
+    .in("entryKey", entryKeysToDelete);
 
-  if (deactivateError) {
+  if (deleteError) {
     throw new Error(
-      `Failed to deactivate removed website content rows: ${deactivateError.message}`,
+      `Failed to delete removed website content rows: ${deleteError.message}`,
     );
   }
 }

--- a/src/server/website-content/queries/getWebsiteContentSection.ts
+++ b/src/server/website-content/queries/getWebsiteContentSection.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { createActionClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
 import { websiteContentSectionSchema } from "../schemas";
 import {
   emptyWebsiteContentCard,
@@ -15,7 +16,8 @@ export async function getWebsiteContentSection(
   section: WebsiteContentSection,
 ): Promise<WebsiteContentSectionData> {
   const parsedSection = websiteContentSectionSchema.parse(section);
-  const supabase = await createActionClient();
+  const cookieStore = await cookies();
+  const supabase = await createClient(cookieStore.getAll());
 
   const { data, error } = await supabase
     .from("WebsiteContent")

--- a/src/server/website-content/queries/getWebsiteContentSectionsSummary.ts
+++ b/src/server/website-content/queries/getWebsiteContentSectionsSummary.ts
@@ -1,6 +1,7 @@
 "use server";
 
-import { createActionClient } from "@/lib/supabase/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
 import type { WebsiteContentSection } from "../types";
 
 type WebsiteContentSectionSummary = {
@@ -40,7 +41,8 @@ function createEmptySummary(): WebsiteContentSectionsSummary {
 }
 
 export async function getWebsiteContentSectionsSummary(): Promise<WebsiteContentSectionsSummary> {
-  const supabase = await createActionClient();
+  const cookieStore = await cookies();
+  const supabase = await createClient(cookieStore.getAll());
 
   const { data, error } = await supabase
     .from("WebsiteContent")


### PR DESCRIPTION
## 🎫 Jira Ticket(s)

<!-- List the Jira IDs associated with this PR. Prefix is BOF- -->

- [BOF-192](https://bugs-over-flowers.atlassian.net/browse/BOF-192)
- [BOF-193](https://bugs-over-flowers.atlassian.net/browse/BOF-193)
- [BOF-194](https://bugs-over-flowers.atlassian.net/browse/BOF-194)
- [BOF-195](https://bugs-over-flowers.atlassian.net/browse/BOF-195)
- [BOF-196](https://bugs-over-flowers.atlassian.net/browse/BOF-196)
- [BOF-197](https://bugs-over-flowers.atlassian.net/browse/BOF-197)

## 📝 Description

<!-- What does this PR do? Why is this change necessary? -->

- Add deactivation logic for removed website-content entries when saving a section, and introduce a server action that summarizes `updatedAt` + saved card counts per section.
- Extend the admin editor UI with multi-select delete mode (checkbox selection, select/unselect all, confirm dialog) and disable editing interactions while in delete mode.
- Add app-wide security headers (CSP + related headers) via `next.config.ts`, and update/extend integration tests for the new server behavior.

## 🛠️ Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻️ Refactoring (no functional changes, no api changes)
- [x] 🎨 Style/UI update
- [x] 🔧 Configuration/Chore

## 📸 Screenshots / Video

<img width="2128" height="683" alt="image" src="https://github.com/user-attachments/assets/5fbabe1c-8267-41da-9951-6b836d350c6a" />
<img width="1522" height="827" alt="image" src="https://github.com/user-attachments/assets/b683c6b6-9624-45ec-bef1-cc74d689fdca" />
<img width="363" height="111" alt="image" src="https://github.com/user-attachments/assets/1bffa57c-dd87-47e1-8cbb-1ae4d8b9ebad" />
<img width="772" height="82" alt="image" src="https://github.com/user-attachments/assets/e0cf9ae7-bf1e-4667-b0f3-f4037c807ce0" />


## ⚠️ Concerns / Known Issues

<!-- Are there any edge cases, unfinished parts, or specific things the reviewer should look out for? -->

## ✅ Checklist

- [x] I have performed a self-review of my code.
- [ ] I have generated Supabase types (if schema changed).
- [x] I have checked for mobile responsiveness.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added necessary documentation (if appropriate).


[BOF-192]: https://bugs-over-flowers.atlassian.net/browse/BOF-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOF-193]: https://bugs-over-flowers.atlassian.net/browse/BOF-193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOF-194]: https://bugs-over-flowers.atlassian.net/browse/BOF-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOF-195]: https://bugs-over-flowers.atlassian.net/browse/BOF-195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOF-196]: https://bugs-over-flowers.atlassian.net/browse/BOF-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BOF-197]: https://bugs-over-flowers.atlassian.net/browse/BOF-197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ